### PR TITLE
StripePromise

### DIFF
--- a/components/Cart/Payment/Payment.js
+++ b/components/Cart/Payment/Payment.js
@@ -4,7 +4,7 @@ import { loadStripe } from "@stripe/stripe-js";
 import FormPayment from "./FormPayment";
 import { STRIPE_TOKEN } from "../../../utils/constants";
 
-const stripePrimise = loadStripe(STRIPE_TOKEN);
+const stripePromise = loadStripe(STRIPE_TOKEN);
 
 export default function Payment(props) {
   const { products, address } = props;
@@ -13,7 +13,7 @@ export default function Payment(props) {
     <div className="payment">
       <div className="title">Pago</div>
       <div className="data">
-        <Elements stripe={stripePrimise}>
+        <Elements stripe={stripePromise}>
           <FormPayment products={products} address={address} />
         </Elements>
       </div>


### PR DESCRIPTION
Según la documentación de stripe es stripePromise: 

import {Elements} from '@stripe/react-stripe-js';
import {loadStripe} from '@stripe/stripe-js';

// Make sure to call `loadStripe` outside of a component’s render to avoid
// recreating the `Stripe` object on every render.
const stripePromise = loadStripe('pk_test_51IicrfCigcj6ye3LEjtdftS92G47KL6ZQMeYLiawhhw3k9IAjsbsC2qhExZe75U0mePWIcxb5DWvrXfqrMh7dnG300bCsIGqF6');

const App = () => {
  return (
    <Elements stripe={stripePromise}>
      <MyCheckoutForm />
    </Elements>
  );
};